### PR TITLE
FIX: Always show the battery in a Darwin platform.

### DIFF
--- a/bin/battery
+++ b/bin/battery
@@ -93,7 +93,7 @@ case $(uname -s) in
                 "CurrentCapacity")
                     export curcap=$value;;
                 "ExternalConnected")
-                    if [ ! -z "$ext" ] && [ "$ext" != "$value" ]; then
+                    if [ -n "$ext" ] && [ "$ext" != "$value" ]; then
                         exit
                     fi
                 ;;


### PR DESCRIPTION
On OS X, the `battery` script doesn't show anything by itself, it
needs the flags `Charging` or `Dircharging`.

This commit's change make the `battery` command to show the status
when no flag is passed.
